### PR TITLE
Fix AttributeError in two_layer_net_autograd.py

### DIFF
--- a/autograd/two_layer_net_autograd.py
+++ b/autograd/two_layer_net_autograd.py
@@ -52,8 +52,9 @@ for t in range(500):
   print(t, loss.data[0])
   
   # Manually zero the gradients before running the backward pass
-  w1.grad.data.zero_()
-  w2.grad.data.zero_()
+  if w1.grad:
+    w1.grad.data.zero_()
+    w2.grad.data.zero_()
 
   # Use autograd to compute the backward pass. This call will compute the
   # gradient of loss with respect to all Variables with requires_grad=True.


### PR DESCRIPTION
The line w1.grad.data.zero_() (previously line 55, now line 56) raised an "AttributeError: 'NoneType' object has no attribute 'data'".
Indeed w1.grad and w2.grad were None at the first loop iteration. Fixed with the if at line 55.